### PR TITLE
Fixed music playing issue

### DIFF
--- a/src/Components/Works/Audio-Visualizer/AudioVisualizer.js
+++ b/src/Components/Works/Audio-Visualizer/AudioVisualizer.js
@@ -93,17 +93,25 @@ class AV extends React.Component{
         jsmediatags.read(files, {
             onSuccess: function(tag) {
                 // Array buffer to base64
-                const data = tag.tags.picture.data;
-                const format = tag.tags.picture.format;
-                let base64String = "";
-                for (let i = 0; i < data.length; i++) {
-                    base64String += String.fromCharCode(data[i]);
+                console.log(tag);
+                try{
+                    const data = tag.tags.picture.data;
+                    const format = tag.tags.picture.format;
+                    let base64String = "";
+                    for (let i = 0; i < data.length; i++) {
+                        base64String += String.fromCharCode(data[i]);
+                    }
+                    // Output media tags
+                    song.title = tag.tags.title;
+                    song.artist = tag.tags.artist;
+                    song.src = URL.createObjectURL(files);
+                    song.albumCover = `url(data:${format};base64,${window.btoa(base64String)})`;
                 }
-                // Output media tags
-                song.title = tag.tags.title;
-                song.artist = tag.tags.artist;
-                song.src = URL.createObjectURL(files);
-                song.albumCover = `url(data:${format};base64,${window.btoa(base64String)})`;
+                catch(err){
+                    song.title = "Unknown";
+                    song.artist = "Unknown";
+                    song.src = URL.createObjectURL(files);
+                }
             },
             onError: function(error) {
                 console.log(error);


### PR DESCRIPTION
Fixed issue where mp3 files that don't contain attributes such as album cover, song title, artist name, etc. could not be added and played. Added text where if the attributes were unavailable to display song title as unknown and artist name as unknown and no album cover.